### PR TITLE
Make original select invisible

### DIFF
--- a/src/scss/core.scss
+++ b/src/scss/core.scss
@@ -42,6 +42,7 @@
   padding: 0 !important;
   position: absolute !important;
   width: 1px !important;
+  visibility: hidden !important;
 }
 
 @import "theme/default/layout";


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Visibility CSS attribute of select element is changed to `hidden`

Changes visibility of original select element, so it becomes ignored by Chrome's find in page visibility.  
This targets a specific use-case, when selects with `multiple` attributes are in the page.

Before, when browsing page in Chrome and using built-in find (CTRL+F) values from select were found. You can observe this behaviour in [Select2 examples page](https://select2.github.io/examples.html) - try looking for `California`. With this change, searching for mentioned string results in only two places being selected, which are on visible elements.
